### PR TITLE
Fix relative imports don't work this way in Python 3

### DIFF
--- a/submit/submit_helpers.py
+++ b/submit/submit_helpers.py
@@ -2,7 +2,7 @@ import os
 from django.http import Http404
 from sendfile import sendfile
 
-import constants
+from . import constants
 from . import settings as submit_settings
 from .models import Submit
 


### PR DESCRIPTION
toto bola jedina drobnost, ktoru som nasiel, co na python 3 nefungovala (although testy by sa zisli na potvrdenie)

closes #17 
